### PR TITLE
[PDI-13700] - S3 File Output Fails when writing to large buckets

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -15,11 +15,63 @@
 	</description>
 
   <import file="build-res/subfloor.xml" />
-
+  <!-- Setup the classpath used for testing -->
+  <path id="test.classpath">
+    <pathelement path="${testclasses.dir}"/>
+    <pathelement path="${classes.dir}"/>
+    <fileset dir="${devlib.dir}">
+      <include name="**/*.jar"/>
+    </fileset>
+    <fileset dir="${testlib.dir}">
+      <include name="**/*.jar"/>
+    </fileset>
+    <fileset dir="${lib.dir}">
+      <include name="**/*.jar"/>
+    </fileset>
+  </path>
   <!--
     AS STATED ABOVE, THE ONLY TASKS THAT SHOULD EXIST IN THIS BUILD FILE ARE
     THE TASKS THAT NEED TO DIFFER FROM THE DEFAULT IMPLEMENTATION OF THE TASKS
     FOUND IN common_build.xml.
   -->
+  <!--=======================================================================
+        test
+
+        Compiles and runs all the tests for the project
+        ====================================================================-->
+  <target name="test-integration" depends="test"
+          description="Compiles and runs unit tests">
+    <junit maxmemory="${junit.maxmemory}"
+           dir="${junit.base.dir}"
+           fork="yes"
+           forkmode="${junit.forkmode}"
+           failureProperty="test.failed"
+           haltonfailure="${junit.haltonfailure}"
+           haltonerror="${junit.haltonerror}"
+           printsummary="yes">
+      <sysproperty key="java.awt.headless" value="${headless.unittest}"/>
+
+      <syspropertyset>
+        <propertyref prefix="junit.sysprop."/>
+        <mapper type="glob" from="junit.sysprop.*" to="*"/>
+      </syspropertyset>
+
+      <classpath refid="test.classpath"/>
+      <formatter type="xml"/>
+      <test name="${testcase}" todir="${testreports.xml.dir}" if="testcase"/>
+      <batchtest fork="yes" todir="${testreports.xml.dir}" unless="testcase">
+        <fileset dir="${testsrc.dir}" casesensitive="yes">
+          <include name="**/*TestIntegration.java"/>
+        </fileset>
+      </batchtest>
+    </junit>
+
+    <junitreport todir="${testreports.html.dir}">
+      <fileset dir="${testreports.xml.dir}">
+        <include name="TEST-*.xml"/>
+      </fileset>
+      <report format="frames" todir="${testreports.html.dir}"/>
+    </junitreport>
+  </target>
 
 </project>

--- a/src/org/pentaho/s3/vfs/S3FileObject.java
+++ b/src/org/pentaho/s3/vfs/S3FileObject.java
@@ -52,7 +52,7 @@ public class S3FileObject extends AbstractFileObject implements FileObject {
     //    service = fileSystem.getS3Service();
   }
 
-  protected String getS3BucketName() throws Exception {
+  protected String getS3BucketName() {
     String bucketName = getName().getPath();
     if ( bucketName.indexOf( DELIMITER, 1 ) > 1 ) {
       // this file is a file, to get the bucket, remove the name from the path
@@ -275,6 +275,7 @@ public class S3FileObject extends AbstractFileObject implements FileObject {
     S3Object s3Object = getS3Object( false );
     s3Object.setKey( newfile.getName().getBaseName() );
     fileSystem.getS3Service().renameObject( getS3BucketName(), getName().getBaseName(), s3Object );
+    s3ChildrenMap.remove( getS3BucketName() );
   }
 
   protected long doGetLastModifiedTime() throws Exception {
@@ -350,4 +351,13 @@ public class S3FileObject extends AbstractFileObject implements FileObject {
     }
   }
 
+  @Override protected void handleCreate( FileType newType ) throws Exception {
+    s3ChildrenMap.remove( getS3BucketName() );
+    super.handleCreate( newType );
+  }
+
+  @Override protected void handleDelete() throws Exception {
+    s3ChildrenMap.remove( getS3BucketName() );
+    super.handleDelete();
+  }
 }

--- a/test-src/org/pentaho/s3/S3Test.java
+++ b/test-src/org/pentaho/s3/S3Test.java
@@ -297,6 +297,36 @@ public class S3Test {
     assertEquals( false, bucket.exists() );
   }
 
+  @Test
+  public void doGetType() throws Exception {
+    assertNotNull( "FileSystemManager is null", fsManager );
+
+    FileObject bucket = fsManager.resolveFile( buildS3URL( "/mdamour_get_type_test" ) );
+    // assertEquals(false, bucket.exists());
+    bucket.createFolder();
+    assertEquals( true, bucket.exists() );
+
+    FileObject s3FileOut = fsManager.resolveFile( buildS3URL( "/mdamour_get_type_test/child01" ) );
+    s3FileOut.createFile();
+    OutputStream out = s3FileOut.getContent().getOutputStream();
+    out.write( HELLO_S3_STR.getBytes() );
+    out.close();
+    assertEquals( "Is not a folder type", FileType.FOLDER, bucket.getType() );
+    assertEquals( "Is not a file type", FileType.FILE, s3FileOut.getType() );
+
+    fsManager.closeFileSystem( bucket.getFileSystem() );
+    assertEquals( "Is not a folder type (after clearing cache)", FileType.FOLDER,
+      fsManager.resolveFile( buildS3URL( "/mdamour_get_type_test" ) ).getType() );
+    assertEquals( "Is not a file type (after clearing cache)", FileType.FILE,
+      fsManager.resolveFile( buildS3URL( "/mdamour_get_type_test/child01" ) ).getType() );
+
+    bucket = fsManager.resolveFile( buildS3URL( "/mdamour_get_type_test" ) );
+    printFileObject( bucket, 0 );
+
+    bucket.delete( deleteFileSelector );
+    assertEquals( false, bucket.exists() );
+  }
+
   private void printFileObject( FileObject fileObject, int depth ) throws Exception {
     for ( int i = 0; i < depth; i++ ) {
       System.out.print( "    " );

--- a/test-src/org/pentaho/s3/S3TestIntegration.java
+++ b/test-src/org/pentaho/s3/S3TestIntegration.java
@@ -43,7 +43,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class S3Test {
+public class S3TestIntegration {
 
   private static FileSystemManager fsManager;
   private static String HELLO_S3_STR = "Hello S3 VFS";
@@ -66,7 +66,7 @@ public class S3Test {
     fsManager = VFS.getManager();
 
     Properties settings = new Properties();
-    settings.load( S3Test.class.getResourceAsStream( "/test-settings.properties" ) );
+    settings.load( S3TestIntegration.class.getResourceAsStream( "/test-settings.properties" ) );
     awsAccessKey = settings.getProperty( "awsAccessKey" );
     awsSecretKey = settings.getProperty( "awsSecretKey" );
 

--- a/test-src/org/pentaho/s3/vfs/S3FileNameParserTestIntegration.java
+++ b/test-src/org/pentaho/s3/vfs/S3FileNameParserTestIntegration.java
@@ -31,7 +31,7 @@ import static junit.framework.Assert.assertEquals;
 /**
  * created by: rfellows date:       5/25/12
  */
-public class S3FileNameParserTest {
+public class S3FileNameParserTestIntegration {
 
   public static String awsAccessKey;
   public static String awsSecretKey;
@@ -43,7 +43,7 @@ public class S3FileNameParserTest {
   @BeforeClass
   public static void init() throws Exception {
     Properties settings = new Properties();
-    settings.load( S3FileUtilTest.class.getResourceAsStream( "/test-settings.properties" ) );
+    settings.load( S3FileUtilTestIntegration.class.getResourceAsStream( "/test-settings.properties" ) );
     awsAccessKey = settings.getProperty( "awsAccessKey" );
     awsSecretKey = settings.getProperty( "awsSecretKey" );
   }

--- a/test-src/org/pentaho/s3/vfs/S3FileObjectTest.java
+++ b/test-src/org/pentaho/s3/vfs/S3FileObjectTest.java
@@ -68,6 +68,7 @@ public class S3FileObjectTest {
     //specify the behaviour of S3 Service
     when( s3ServiceMock.getBucket( BUCKET_NAME ) ).thenReturn( testBucket );
     when( s3ServiceMock.getObject( testBucket, OBJECT_NAME ) ).thenReturn( s3Object );
+    when( s3ServiceMock.getObject( BUCKET_NAME, OBJECT_NAME ) ).thenReturn( s3Object );
     when( s3ServiceMock.createBucket( BUCKET_NAME ) )
       .thenThrow( new S3ServiceException() ); // throw exception if bucket exists
     when( fileSystemSpy.getS3Service() ).thenReturn( s3ServiceMock );

--- a/test-src/org/pentaho/s3/vfs/S3FileUtilTestIntegration.java
+++ b/test-src/org/pentaho/s3/vfs/S3FileUtilTestIntegration.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * created by: rfellows date:       5/21/12
  */
-public class S3FileUtilTest {
+public class S3FileUtilTestIntegration {
 
   public static String awsAccessKey;
   public static String awsSecretKey;
@@ -41,7 +41,7 @@ public class S3FileUtilTest {
   @BeforeClass
   public static void init() throws Exception {
     Properties settings = new Properties();
-    settings.load( S3FileUtilTest.class.getResourceAsStream( "/test-settings.properties" ) );
+    settings.load( S3FileUtilTestIntegration.class.getResourceAsStream( "/test-settings.properties" ) );
     awsAccessKey = settings.getProperty( "awsAccessKey" );
     awsSecretKey = settings.getProperty( "awsSecretKey" );
   }

--- a/test-src/test-settings.properties
+++ b/test-src/test-settings.properties
@@ -1,0 +1,2 @@
+awsAccessKey=<ReplaceMe>
+awsSecretKey=<ReplaceMe>


### PR DESCRIPTION
* Added handles for create and deletion which invalidate filecache - the reason for test failing
* Changed the way of determining object`s type - do not cache all children - so TextFileOutput step into s3 is working and not failing with OOM exception. But still if we try to load all children using function listChildren (for example with the help of some browse dialog) - we will fail with OOM. Most of all it is related but not the same bug and for its fixing need to change both logic of our VFS browser implementation (provide paging and try to load children in chunks) and architecture of S3vfs (try to find the way to decrease memory needed for one object)