### PR TITLE
 [PDI-17867] Fixes not closing connections leading to timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,10 @@
     <slf4j-log4j12.version>1.7.7</slf4j-log4j12.version>
 
     <!-- Test dependencies -->
-    <junit.version>4.4</junit.version>
-    <mockito.version>1.8.4</mockito.version>
+    <junit.version>4.12</junit.version>
+    <mockito.version>1.10.19</mockito.version>
+    <powermock.version>1.7.4</powermock.version>
+    <guava.version>19.0</guava.version>
   </properties>
 
   <scm>
@@ -51,6 +53,12 @@
 
   <!-- Third-party dependencies -->
   <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
@@ -77,20 +85,14 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.11.275</version>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>${aws-java-sdk.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j-api.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j-log4j12.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -119,9 +121,10 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-bundle</artifactId>
-      <version>1.11.314</version>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-reflect</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,13 @@
     <commons-vfs2.version>2.2</commons-vfs2.version>
     <jets3t.version>0.9.4</jets3t.version>
     <slf4j-api.version>1.7.7</slf4j-api.version>
-    <slf4j-log4j12.version>1.7.7</slf4j-log4j12.version>
+    <httpclient.version>4.5</httpclient.version>
+    <guava.version>19.0</guava.version>
 
     <!-- Test dependencies -->
     <junit.version>4.12</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.7.4</powermock.version>
-    <guava.version>19.0</guava.version>
   </properties>
 
   <scm>
@@ -51,8 +51,24 @@
     <tag>HEAD</tag>
   </scm>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${commons-codec.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <!-- Third-party dependencies -->
   <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -85,8 +101,12 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>${aws-java-sdk.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -94,11 +114,6 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j-api.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
+++ b/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
@@ -1,0 +1,85 @@
+/*!
+ * Copyright 2019 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.s3n.vfs;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.reflect.Whitebox.getInternalState;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+public class S3NFileObjectTest {
+
+  /**
+   * Make sure the existing S3Object is closed before a new one is created.
+   * Confirm that the new object is actually new and not the existing one.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void activateContentWithS3Object() throws IOException {
+    S3NFileObject s3n = mock( S3NFileObject.class );
+    doReturn( mock( S3Object.class ) ).when( s3n ).getS3Object();
+    doCallRealMethod().when( s3n ).activateContent();
+
+    S3Object s3object = mock( S3Object.class );
+    setInternalState( s3n, "s3Object", s3object );
+
+    s3n.activateContent();
+
+    verify( s3object, times( 1 ) ).close();
+    assertNotEquals( s3object, (S3Object) getInternalState( s3n, "s3Object" ) );
+  }
+
+  @Test
+  public void activateContentWithNull() throws IOException {
+    S3NFileObject s3n = mock( S3NFileObject.class );
+    doReturn( mock( S3Object.class ) ).when( s3n ).getS3Object();
+    doCallRealMethod().when( s3n ).activateContent();
+
+    s3n.activateContent();
+
+    assertNotNull( getInternalState( s3n, "s3Object" ) );
+  }
+
+  @Test
+  public void getContentSize() {
+    ObjectMetadata meta = mock( ObjectMetadata.class );
+    doReturn( 1L ).when( meta ).getContentLength();
+
+    S3Object s3object = mock( S3Object.class );
+    doReturn( meta ).when( s3object ).getObjectMetadata();
+
+    S3NFileObject s3n = mock( S3NFileObject.class );
+    doReturn( s3object ).when( s3n ).getS3Object();
+    doCallRealMethod().when( s3n ).doGetContentSize();
+
+    assertEquals( 1L, s3n.doGetContentSize() );
+  }
+}


### PR DESCRIPTION
This is a series of PRs to update the version of AWS Java SDK across all repositories.
See: https://github.com/pentaho/maven-parent-poms/pull/114

The first commit is the actual fix. The major issue was the method `doGetContentSize()` getting a new S3 object in order to get the content length and never releasing it. The logic implemented in `getChildren()` is totally unnecessary and would actually degrade performance.

With the current contents in my S3 bucket, the **Get file names step** was taking 2.2 seconds to complete and now takes 0.0 seconds. Running this 50 times shows no signs of performance degradation or leaked objects.

The AWS Java SDK was updated due to: https://github.com/aws/aws-sdk-java-v2/issues/438

@pentaho/tatooine @ssamora 