### PR TITLE
[PDI-17549] S3 Access Key and Secret Access Key can no longer be used…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <jets3t.version>0.9.4</jets3t.version>
     <slf4j-api.version>1.7.7</slf4j-api.version>
     <slf4j-log4j12.version>1.7.7</slf4j-log4j12.version>
-    <commons-codec.version>1.10</commons-codec.version>
+    <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
 
     <!-- Test dependencies -->
     <junit.version>4.4</junit.version>
@@ -98,6 +98,12 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>${commons-codec.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>pentaho-kettle</groupId>
+      <artifactId>kettle-core</artifactId>
+      <version>${pdi.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->

--- a/src/main/java/org/pentaho/amazon/s3/S3Util.java
+++ b/src/main/java/org/pentaho/amazon/s3/S3Util.java
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.amazon.s3;
+
+import org.pentaho.di.core.util.StringUtil;
+
+public final class S3Util {
+
+  /** System property name for the AWS access key ID */
+  public static final String ACCESS_KEY_SYSTEM_PROPERTY = "aws.accessKeyId";
+
+  /** System property name for the AWS secret key */
+  public static final String SECRET_KEY_SYSTEM_PROPERTY = "aws.secretKey";
+
+  public static boolean hasChanged( String previousValue, String currentValue ) {
+    if ( !StringUtil.isEmpty( previousValue ) && StringUtil.isEmpty( currentValue ) ) {
+      return true;
+    }
+    if ( StringUtil.isEmpty( previousValue ) && !StringUtil.isEmpty( currentValue ) ) {
+      return true;
+    }
+    if ( !StringUtil.isEmpty( previousValue ) && !StringUtil.isEmpty( currentValue ) && !currentValue.equals( previousValue ) ) {
+      return true;
+    }
+    return false;
+  }
+
+  private S3Util() { }
+
+}

--- a/src/main/java/org/pentaho/s3/vfs/S3FileSystem.java
+++ b/src/main/java/org/pentaho/s3/vfs/S3FileSystem.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,15 +33,11 @@ import org.jets3t.service.S3Service;
 import org.jets3t.service.impl.rest.httpclient.RestS3Service;
 import org.jets3t.service.security.AWSCredentials;
 import org.jets3t.service.security.ProviderCredentials;
+import org.pentaho.amazon.s3.S3Util;
 
 public class S3FileSystem extends AbstractFileSystem implements FileSystem {
 
   private S3Service service;
-  /** System property name for the AWS access key ID */
-  public static final String ACCESS_KEY_SYSTEM_PROPERTY = "aws.accessKeyId";
-
-  /** System property name for the AWS secret key */
-  public  static final String SECRET_KEY_SYSTEM_PROPERTY = "aws.secretKey";
 
   private String awsAccessKeyCache;
 
@@ -62,13 +58,13 @@ public class S3FileSystem extends AbstractFileSystem implements FileSystem {
   }
 
   public S3Service getS3Service() {
-    String awsAccessKeySystemEnvValue = System.getProperty( ACCESS_KEY_SYSTEM_PROPERTY );
-    String awsSecretKeySystemEnvValue = System.getProperty( SECRET_KEY_SYSTEM_PROPERTY );
+    String awsAccessKeySystemEnvValue = System.getProperty( S3Util.ACCESS_KEY_SYSTEM_PROPERTY );
+    String awsSecretKeySystemEnvValue = System.getProperty( S3Util.SECRET_KEY_SYSTEM_PROPERTY );
 
     if ( service == null || service.getProviderCredentials() == null
       || service.getProviderCredentials().getAccessKey() == null || ( service != null
-        && hasChanged( awsAccessKeyCache, awsAccessKeySystemEnvValue )
-            && hasChanged( awsSecretKeyCache, awsSecretKeySystemEnvValue ) ) ) {
+        && S3Util.hasChanged( awsAccessKeyCache, awsAccessKeySystemEnvValue )
+            && S3Util.hasChanged( awsSecretKeyCache, awsSecretKeySystemEnvValue ) ) ) {
 
       UserAuthenticator userAuthenticator =
         DefaultFileSystemConfigBuilder.getInstance().getUserAuthenticator( getFileSystemOptions() );
@@ -98,22 +94,5 @@ public class S3FileSystem extends AbstractFileSystem implements FileSystem {
       }
     }
     return service;
-  }
-
-  private boolean isEmpty( String value ) {
-    return value == null || value.length() <= 0;
-  }
-
-  private boolean hasChanged( String previousValue, String currentValue ) {
-    if ( !isEmpty( previousValue ) && isEmpty( currentValue ) ) {
-      return true;
-    }
-    if ( isEmpty( previousValue ) && !isEmpty( currentValue ) ) {
-      return true;
-    }
-    if ( !isEmpty( previousValue ) && !isEmpty( currentValue ) && !currentValue.equals( previousValue ) ) {
-      return true;
-    }
-    return false;
   }
 }

--- a/src/main/java/org/pentaho/s3n/vfs/S3NFileSystem.java
+++ b/src/main/java/org/pentaho/s3n/vfs/S3NFileSystem.java
@@ -28,9 +28,12 @@ import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.AbstractFileName;
 import org.apache.commons.vfs2.provider.AbstractFileSystem;
+import org.pentaho.amazon.s3.S3Util;
 
 public class S3NFileSystem extends AbstractFileSystem implements FileSystem {
 
+  private String awsAccessKeyCache;
+  private String awsSecretKeyCache;
   private AmazonS3 client;
 
   protected S3NFileSystem( final FileName rootName, final FileSystemOptions fileSystemOptions ) {
@@ -47,17 +50,25 @@ public class S3NFileSystem extends AbstractFileSystem implements FileSystem {
   }
 
   public AmazonS3 getS3Client() {
-    if ( client == null ) {
+    if ( client == null || hasClientChangedCredentials() ) {
       try {
         client = AmazonS3ClientBuilder.standard()
           .enableForceGlobalBucketAccess()
           .withRegion( Regions.DEFAULT_REGION )
           .build();
+        awsAccessKeyCache = System.getProperty( S3Util.ACCESS_KEY_SYSTEM_PROPERTY );
+        awsSecretKeyCache = System.getProperty( S3Util.SECRET_KEY_SYSTEM_PROPERTY );
       } catch ( Throwable t ) {
         System.out.println( "Could not get an S3Client" );
         t.printStackTrace();
       }
     }
     return client;
+  }
+
+  private boolean hasClientChangedCredentials() {
+    return client != null
+      && ( S3Util.hasChanged( awsAccessKeyCache, System.getProperty( S3Util.ACCESS_KEY_SYSTEM_PROPERTY ) )
+      || S3Util.hasChanged( awsSecretKeyCache, System.getProperty( S3Util.SECRET_KEY_SYSTEM_PROPERTY ) ) );
   }
 }


### PR DESCRIPTION
… as variables to parameterize jobs or transformations

Note: the <commons-codec.version>1.10</commons-codec.version> was removed because it was duplicated.

This PR Must be merged before https://github.com/pentaho/big-data-plugin/pull/1642

@pentaho-lmartins 