### PR TITLE
[PDI-18159] Text File Input "Get Fields" fails for S3 Location/Source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,13 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-reflect</artifactId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/org/pentaho/s3/vfs/S3FileObjectTest.java
+++ b/src/test/java/org/pentaho/s3/vfs/S3FileObjectTest.java
@@ -30,6 +30,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.UploadPartResult;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.CacheStrategy;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
@@ -39,12 +40,16 @@ import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.FilesCache;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.VfsComponentContext;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.File;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,7 +58,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.AbstractMap.SimpleEntry;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -66,7 +75,8 @@ import static org.mockito.Mockito.atMost;
 /**
  * created by: dzmitry_bahdanovich date: 10/18/13
  */
-
+@RunWith( PowerMockRunner.class )
+@PowerMockIgnore( { "javax.management.*", "com.amazonaws.http.conn.ssl.*", "javax.net.ssl.*" } )
 public class S3FileObjectTest {
 
   public static final String HOST = "S3";
@@ -187,7 +197,10 @@ public class S3FileObjectTest {
   }
 
   @Test
+  @PrepareForTest( { IOUtils.class } )
   public void testDoGetInputStream() throws Exception {
+    PowerMockito.mockStatic( IOUtils.class );
+    Mockito.when( IOUtils.toByteArray( s3ObjectInputStream ) ).thenReturn( new byte[] {} );
     assertNotNull( s3FileObjectBucketSpy.getInputStream() );
   }
 

--- a/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
+++ b/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
@@ -27,6 +27,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.CacheStrategy;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
@@ -38,8 +39,13 @@ import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.VfsComponentContext;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.pentaho.s3.vfs.S3FileNameParser;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,13 +53,23 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.verify;
 
 /**
  * created by: dzmitry_bahdanovich date: 10/18/13
  */
-
+@RunWith( PowerMockRunner.class )
+@PowerMockIgnore( { "javax.management.*", "com.amazonaws.http.conn.ssl.*", "javax.net.ssl.*" } )
 public class S3NFileObjectTest {
 
   public static final String HOST = "S3";
@@ -147,7 +163,10 @@ public class S3NFileObjectTest {
   }
 
   @Test
+  @PrepareForTest( { IOUtils.class } )
   public void testDoGetInputStream() throws Exception {
+    PowerMockito.mockStatic( IOUtils.class );
+    Mockito.when( IOUtils.toByteArray( s3ObjectInputStream ) ).thenReturn( new byte[] {} );
     assertNotNull( s3FileObjectBucketSpy.getInputStream() );
   }
 


### PR DESCRIPTION
@peterrinehart @tkafalas @pentaho/tatooine 

Hi guys can you have a look at this please. What happens is that the exhaustive operations of the "Get Fields" ends up with the stream closing and no more data can be retrieved.
I saw this in the documentation:
"Note: The method is a simple getter and does not actually create a stream. If you retrieve an S3Object, you should close this input stream as soon as possible, because the object contents aren't buffered in memory and stream directly from Amazon S3. Further, failure to close this stream can cause the request pool to become blocked."
from
https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/S3Object.html#getObjectContent--