### PR TITLE
[PDI-18159] Text File Input "Get Fields" fails for S3 Location/Source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,13 +128,7 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-reflect</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/org/pentaho/s3common/S3CommonFileObject.java
+++ b/src/main/java/org/pentaho/s3common/S3CommonFileObject.java
@@ -25,15 +25,14 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.provider.AbstractFileName;
 import org.apache.commons.vfs2.provider.AbstractFileObject;
+import org.apache.commons.vfs2.util.MonitorInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,10 +70,7 @@ public abstract class S3CommonFileObject extends AbstractFileObject {
   protected InputStream doGetInputStream() throws Exception {
     logger.debug( "Accessing content {}", getQualifiedName() );
     activateContent();
-    S3ObjectInputStream inputstream = s3Object.getObjectContent();
-    byte[] content = IOUtils.toByteArray( inputstream );
-    inputstream.close();
-    s3ObjectInputStream = new ByteArrayInputStream( content );
+    s3ObjectInputStream = new MonitorInputStream( s3Object.getObjectContent() );
     return s3ObjectInputStream;
   }
 
@@ -211,7 +207,6 @@ public abstract class S3CommonFileObject extends AbstractFileObject {
       injectType( FileType.FOLDER );
       return;
     }
-
     try {
       // 1. Is it an existing file?
       s3Object = getS3Object();

--- a/src/test/java/org/pentaho/s3/vfs/S3FileObjectTest.java
+++ b/src/test/java/org/pentaho/s3/vfs/S3FileObjectTest.java
@@ -30,7 +30,6 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.UploadPartResult;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.CacheStrategy;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
@@ -42,14 +41,7 @@ import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.VfsComponentContext;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,8 +67,6 @@ import static org.mockito.Mockito.atMost;
 /**
  * created by: dzmitry_bahdanovich date: 10/18/13
  */
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( { "javax.management.*", "com.amazonaws.http.conn.ssl.*", "javax.net.ssl.*" } )
 public class S3FileObjectTest {
 
   public static final String HOST = "S3";
@@ -197,10 +187,7 @@ public class S3FileObjectTest {
   }
 
   @Test
-  @PrepareForTest( { IOUtils.class } )
   public void testDoGetInputStream() throws Exception {
-    PowerMockito.mockStatic( IOUtils.class );
-    Mockito.when( IOUtils.toByteArray( s3ObjectInputStream ) ).thenReturn( new byte[] {} );
     assertNotNull( s3FileObjectBucketSpy.getInputStream() );
   }
 

--- a/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
+++ b/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
@@ -27,7 +27,6 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.CacheStrategy;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
@@ -39,13 +38,7 @@ import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.VfsComponentContext;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,8 +61,6 @@ import static org.mockito.Mockito.verify;
 /**
  * created by: dzmitry_bahdanovich date: 10/18/13
  */
-@RunWith( PowerMockRunner.class )
-@PowerMockIgnore( { "javax.management.*", "com.amazonaws.http.conn.ssl.*", "javax.net.ssl.*" } )
 public class S3NFileObjectTest {
 
   public static final String HOST = "S3";
@@ -163,10 +154,7 @@ public class S3NFileObjectTest {
   }
 
   @Test
-  @PrepareForTest( { IOUtils.class } )
   public void testDoGetInputStream() throws Exception {
-    PowerMockito.mockStatic( IOUtils.class );
-    Mockito.when( IOUtils.toByteArray( s3ObjectInputStream ) ).thenReturn( new byte[] {} );
     assertNotNull( s3FileObjectBucketSpy.getInputStream() );
   }
 


### PR DESCRIPTION
Using the MonitorInputStream instead. "An InputStream that provides buffering and end-of-stream monitoring"
Tried the previous version with a large file in S3. As expected a OutOfMemoryError occured. 
With this version no OutOfMemoryError occurs. Tried the GetFields error it self along with some S3 Input and Output steps copying large files from one place to another.
@pentaho-lmartins 