### PR TITLE
[BACKLOG-32173] Independent input streams need to be returned for each

### DIFF
--- a/src/main/java/org/pentaho/s3common/S3CommonFileInputStream.java
+++ b/src/main/java/org/pentaho/s3common/S3CommonFileInputStream.java
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2019 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.s3common;
+
+import com.amazonaws.services.s3.model.S3Object;
+import org.apache.commons.vfs2.util.MonitorInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class S3CommonFileInputStream extends MonitorInputStream {
+
+  private S3Object s3Object;
+
+  public S3CommonFileInputStream( InputStream in, S3Object s3Object ) {
+    super( in );
+    this.s3Object = s3Object;
+  }
+
+  @Override
+  protected void onClose() throws IOException {
+    super.onClose();
+    this.s3Object.close();
+  }
+}

--- a/src/test/java/org/pentaho/s3/vfs/S3FileObjectTest.java
+++ b/src/test/java/org/pentaho/s3/vfs/S3FileObjectTest.java
@@ -248,6 +248,7 @@ public class S3FileObjectTest {
     S3FileObject newFile = new S3FileObject( newFileName, fileSystemSpy );
     ArgumentCaptor<CopyObjectRequest> copyObjectRequestArgumentCaptor = ArgumentCaptor.forClass( CopyObjectRequest.class );
     when( s3ServiceMock.doesBucketExistV2( someNewBucketName ) ).thenReturn( true );
+    s3FileObjectFileSpy.doAttach();
     s3FileObjectFileSpy.moveTo( newFile );
 
     verify( s3ServiceMock ).copyObject( copyObjectRequestArgumentCaptor.capture() );
@@ -308,7 +309,7 @@ public class S3FileObjectTest {
   public void testDoDetach() throws Exception {
     s3FileObjectFileSpy.doAttach();
     s3FileObjectFileSpy.doDetach();
-    verify( s3ObjectMock, times( 2 ) ).close();
+    verify( s3ObjectMock, times( 1 ) ).close();
   }
 
   @Test

--- a/src/test/java/org/pentaho/s3common/S3CommonFileObjectTest.java
+++ b/src/test/java/org/pentaho/s3common/S3CommonFileObjectTest.java
@@ -44,32 +44,6 @@ public class S3CommonFileObjectTest {
    * @throws IOException
    */
   @Test
-  public void activateContentWithS3Object() throws IOException {
-    S3CommonFileObject s3n = mock( S3CommonFileObject.class );
-    doReturn( mock( S3Object.class ) ).when( s3n ).getS3Object();
-    doCallRealMethod().when( s3n ).activateContent();
-
-    S3Object s3object = mock( S3Object.class );
-    setInternalState( s3n, "s3Object", s3object );
-
-    s3n.activateContent();
-
-    verify( s3object, times( 1 ) ).close();
-    assertNotEquals( s3object, (S3Object) getInternalState( s3n, "s3Object" ) );
-  }
-
-  @Test
-  public void activateContentWithNull() throws IOException {
-    S3CommonFileObject s3n = mock( S3CommonFileObject.class );
-    doReturn( mock( S3Object.class ) ).when( s3n ).getS3Object();
-    doCallRealMethod().when( s3n ).activateContent();
-
-    s3n.activateContent();
-
-    assertNotNull( getInternalState( s3n, "s3Object" ) );
-  }
-
-  @Test
   public void getContentSize() {
     ObjectMetadata meta = mock( ObjectMetadata.class );
     doReturn( 1L ).when( meta ).getContentLength();

--- a/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
+++ b/src/test/java/org/pentaho/s3n/vfs/S3NFileObjectTest.java
@@ -249,7 +249,7 @@ public class S3NFileObjectTest {
   public void testDoDetach() throws Exception {
     s3FileObjectFileSpy.doAttach();
     s3FileObjectFileSpy.doDetach();
-    verify( s3ObjectMock, times( 2 ) ).close();
+    verify( s3ObjectMock, times( 1 ) ).close();
   }
 
   @Test


### PR DESCRIPTION
call to doGetInputStream; more than one section of code may create and
read from the input stream at once (e.g. Avro) and the file object could be disposed
by the file system before a reader is done with the input stream.