### PR TITLE
[PDI-18723] Text File Input for S3 VFS file in parallel errors out wi…

### DIFF
--- a/src/main/java/org/pentaho/s3common/S3CommonFileObject.java
+++ b/src/main/java/org/pentaho/s3common/S3CommonFileObject.java
@@ -52,7 +52,6 @@ public abstract class S3CommonFileObject extends AbstractFileObject {
   protected String key;
   protected S3Object s3Object;
   protected ObjectMetadata s3ObjectMetadata;
-  protected FileType fileType;
 
   protected S3CommonFileObject( final AbstractFileName name, final S3CommonFileSystem fileSystem ) {
     super( name, fileSystem );
@@ -77,20 +76,6 @@ public abstract class S3CommonFileObject extends AbstractFileObject {
   @Override
   protected FileType doGetType() throws Exception {
     return getType();
-  }
-
-  @Override
-  protected void injectType( FileType fileType ) {
-    this.fileType = fileType;
-    super.injectType( fileType );
-  }
-
-  @Override
-  public FileType getType() throws FileSystemException {
-    if ( fileType == null ) {
-      fileType = super.getType();
-    }
-    return fileType;
   }
 
   @Override


### PR DESCRIPTION
…th: Could not determine the last modified timestamp

The error reported did not occur every time. it was something that could occur from time to time. 
This was due to the call made in: https://github.com/pentaho/pentaho-kettle/blob/3d4f59a81288fbb11178a02cca7e88ad15215ae6/engine/src/main/java/org/pentaho/di/trans/steps/file/BaseFileInputStep.java#L448

it could occur that the s3 file is attached and has content, thus making this call, but when we get to the getLastModifiedTime() in the commons-vfs https://github.com/apache/commons-vfs/blob/175c63d5aa166d14af610b90e29a95c070cb4123/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/DefaultFileContent.java#L147 another getType call is made. At this point we could have returned a type that was stored in the S3CommonFileObject but the S3 file is not attached and thus hasAttributes is false, causing the exception.
This PR removes the storing of the fileType which will cause calls to getType to attach again the S3 Object.

Storing of the file type in the S3CommonFileObject was done in e2b2aa6 in order to improve performance. 
This can be removed due to the latest changes, in particular f17ac3b91670684b4804772216f9858857e0cb6f

@pentaho-lmartins 
